### PR TITLE
Fixes for Atom feeds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Build and Test Pull Request
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-and-test:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,4 +28,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: distributions
           path: app/build/distributions/*

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,3 +24,8 @@ jobs:
 
       - name: Build and Test
         run: ./gradlew build test
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: app/build/distributions/*

--- a/core/src/main/kotlin/com/munzenberger/feed/handler/SendEmail.kt
+++ b/core/src/main/kotlin/com/munzenberger/feed/handler/SendEmail.kt
@@ -69,7 +69,7 @@ class SendEmail : ItemHandler {
                 setFrom(from, context.feedTitle)
                 item.timestampAsInstant?.let { sentDate = Date.from(it) }
                 subject = item.title
-                setHtmlMsg(item.toHtmlMessage(templateURL))
+                setHtmlMsg(item.toHtmlMessage(templateURL, context))
                 mailSession = session
                 buildMimeMessage()
             }
@@ -88,8 +88,11 @@ class SendEmail : ItemHandler {
     }
 }
 
-internal fun Item.toHtmlMessage(template: URL): String {
-    val mailItem = MailItem(this)
+internal fun Item.toHtmlMessage(
+    template: URL,
+    context: FeedContext,
+): String {
+    val mailItem = MailItem(context, this)
     val context = VelocityContext().apply { put("item", mailItem) }
     val writer = StringWriter()
     val reader = InputStreamReader(template.openStream())
@@ -98,12 +101,14 @@ internal fun Item.toHtmlMessage(template: URL): String {
 }
 
 class MailItem(
+    context: FeedContext,
     item: Item,
 ) {
     val description: String = item.content.encodeForEmail()
     val link: String = item.link
     val id: String = item.guid
     val enclosures: List<Enclosure> = item.enclosures
+    val source = context.sourceName
 }
 
 private fun String.encodeForEmail(): String {

--- a/core/src/main/kotlin/com/munzenberger/feed/source/AtomXMLFeedParser.kt
+++ b/core/src/main/kotlin/com/munzenberger/feed/source/AtomXMLFeedParser.kt
@@ -159,18 +159,28 @@ internal object AtomXMLFeedParser : XMLFeedParser {
             }
         }
 
+        content.value =
+            when (content.type.lowercase()) {
+                // https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.3
+                "xhtml" -> parseContentAsXhtml(eventReader)
+                else -> parseCharacterData(eventReader)
+            }
+    }
+
+    private fun parseContentAsXhtml(eventReader: XMLEventReader): String {
         val valueWriter = StringWriter()
 
         while (eventReader.hasNext()) {
             val event = eventReader.nextEvent()
 
             if (event.isEndElement && event.asEndElement().name.localPart == CONTENT) {
-                content.value = valueWriter.toString()
-                return
+                break
             }
 
             event.writeAsEncodedUnicode(valueWriter)
         }
+
+        return valueWriter.toString()
     }
 
     private fun parseCategory(

--- a/core/src/main/kotlin/com/munzenberger/feed/source/AtomXMLFeedParser.kt
+++ b/core/src/main/kotlin/com/munzenberger/feed/source/AtomXMLFeedParser.kt
@@ -54,7 +54,7 @@ private fun AtomFeed.toFeed() =
 private fun AtomEntry.toItem() =
     Item(
         title = title,
-        content = contents.firstOrNull()?.decodedValue ?: summary,
+        content = contents.firstOrNull { it.value.isNotBlank() }?.decodedValue ?: summary,
         link = links.firstOrNull { it.rel.isEmpty() || it.rel == "alternate" }?.href ?: "",
         guid = id,
         timestamp = updated,
@@ -105,6 +105,13 @@ internal object AtomXMLFeedParser : XMLFeedParser {
             val event = eventReader.nextEvent()
 
             if (event.isStartElement) {
+                val name = event.asStartElement().name
+
+                // ignore any elements not core to Atom
+                if (name.prefix.isNotBlank()) {
+                    continue
+                }
+
                 when (event.asStartElement().name.localPart) {
                     TITLE -> entry.title = parseCharacterData(eventReader)
                     LINK -> entry.links += AtomLink().apply { parseLink(this, event.asStartElement()) }

--- a/core/src/main/resources/com/munzenberger/feed/handler/SendEmail.vm
+++ b/core/src/main/resources/com/munzenberger/feed/handler/SendEmail.vm
@@ -1,5 +1,5 @@
 #**
- Copyright 2023 Brian Munzenberger
+ Copyright 2025 Brian Munzenberger
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -34,4 +34,5 @@
 		</div>
 	</body>
 </html>
-<!-- ${item.id} -->
+<!-- Feed source: ${item.source} -->
+<!-- Item ID: ${item.id} -->

--- a/core/src/test/kotlin/com/munzenberger/feed/handler/SendEmailTest.kt
+++ b/core/src/test/kotlin/com/munzenberger/feed/handler/SendEmailTest.kt
@@ -1,12 +1,20 @@
 package com.munzenberger.feed.handler
 
+import com.munzenberger.feed.FeedContext
 import com.munzenberger.feed.Item
-import org.junit.Assert.assertNotNull
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SendEmailTest {
     @Test
     fun `it should format an Item into an email message`() {
+        val context =
+            mockk<FeedContext> {
+                every { sourceName } returns "test source"
+            }
+
         val item =
             Item(
                 title = "Test email title",
@@ -18,8 +26,28 @@ class SendEmailTest {
                 categories = emptyList(),
             )
 
-        val message = item.toHtmlMessage(SendEmail.templateURL)
+        val message = item.toHtmlMessage(SendEmail.templateURL, context)
 
-        assertNotNull(message)
+        val expected =
+            """
+            
+            <html>
+            	<head></head>
+            	<body>
+            		<div>
+            				Test email content
+            		</div>
+            		<hr>
+            		<div>
+            				<p>Article: <a href="Test email link">Test email link</a></p>
+            		</div>
+            	</body>
+            </html>
+            <!-- Feed source: test source -->
+            <!-- Item ID: Test email guid -->
+
+            """.trimIndent()
+
+        assertEquals(expected, message)
     }
 }

--- a/core/src/test/kotlin/com/munzenberger/feed/source/XMLFeedSourceTest.kt
+++ b/core/src/test/kotlin/com/munzenberger/feed/source/XMLFeedSourceTest.kt
@@ -108,6 +108,15 @@ class XMLFeedSourceTest {
                             enclosures = emptyList(),
                             categories = emptyList(),
                         ),
+                        Item(
+                            title = "HTML entry with CDATA",
+                            content = """<div style="info"><p>This is the entry content.</p></div>""",
+                            link = "http://example.org/2003/12/13/atom03.html",
+                            guid = "urn:uuid:eab40f86-0bd6-4800-9685-98ddddb9548a",
+                            timestamp = "2025-08-27T04:25:02Z",
+                            enclosures = emptyList(),
+                            categories = emptyList(),
+                        ),
                     ),
             )
 

--- a/core/src/test/resources/com/munzenberger/feed/source/atom.xml
+++ b/core/src/test/resources/com/munzenberger/feed/source/atom.xml
@@ -55,4 +55,17 @@
             <email>johndoe@example.com</email>
         </author>
     </entry>
+
+    <entry>
+        <title>HTML entry with CDATA</title>
+        <link rel="alternate" type="text/html" href="http://example.org/2003/12/13/atom03.html"/>
+        <id>urn:uuid:eab40f86-0bd6-4800-9685-98ddddb9548a</id>
+        <updated>2025-08-27T04:25:02Z</updated>
+        <summary>HTML summary</summary>
+        <content type="html"><![CDATA[<div style="info"><p>This is the entry content.</p></div>]]></content>
+        <author>
+            <name>John Doe</name>
+            <email>johndoe@example.com</email>
+        </author>
+    </entry>
 </feed>


### PR DESCRIPTION
* Ignore non-core elements
* Handle content type parsing of XHTML vs. text